### PR TITLE
Add versioning to builds

### DIFF
--- a/app.c
+++ b/app.c
@@ -74,6 +74,7 @@ char APP_INIT_MSG[] = "\r\nAPP INITIALIZED\r\n";
 char SD_MOUNT_FAIL[] = "SD MOUNT FAIL\r\n";
 char SD_SUCCESS_MSG[] = "SD SUCCESS\r\n";
 char SD_FAILED_MSG[] = "SD FAIL\r\n";
+char VERSION_MSG[] = "Firmware Version: " VERSION_STRING "\r\n";
 
 // USART Definitions
 // *****************************************************************************
@@ -106,7 +107,8 @@ FIL Fil;		/* File object needed for each open file */
 
 void APP_Initialize ( void )
 {
-//    SERCOM3_USART_Write(&APP_INIT_MSG[0], sizeof(APP_INIT_MSG));
+    /* Initialize version information */
+    SERCOM3_USART_Write(&VERSION_MSG[0], sizeof(VERSION_MSG));
     disableGPIOs();
     RTC_Initialize();
     RTC_Timer32Start();

--- a/app.h
+++ b/app.h
@@ -60,6 +60,7 @@
 #include <ctype.h>
 #include "configuration.h"
 #include "system/fs/sys_fs.h"
+#include "version.h"
 
 // DOM-IGNORE-BEGIN
 #ifdef __cplusplus  // Provide C++ Compatibility
@@ -152,6 +153,9 @@ typedef struct
     APP_STATES                  state;           
 
     int32_t                     nBytesRead;
+
+    /* Version information */
+    const VERSION_INFO*         version;
 } APP_DATA;
 
 

--- a/version.c
+++ b/version.c
@@ -1,0 +1,51 @@
+/*******************************************************************************
+  Version Information Implementation File
+
+  Company:
+    Artemis Cubesat PDU
+
+  File Name:
+    version.c
+
+  Summary:
+    This file implements the version information functions.
+
+  Description:
+    This file contains the implementation of functions that provide version
+    information for the PDU firmware.
+*******************************************************************************/
+
+#include "version.h"
+
+// *****************************************************************************
+// *****************************************************************************
+// Section: Global Variables
+// *****************************************************************************
+// *****************************************************************************
+
+/* Global version information structure */
+static const VERSION_INFO versionInfo = {
+    .major = VERSION_MAJOR,
+    .minor = VERSION_MINOR,
+    .patch = VERSION_PATCH,
+    .build = VERSION_BUILD
+};
+
+/* Global version string */
+static const char versionString[] = VERSION_STRING;
+
+// *****************************************************************************
+// *****************************************************************************
+// Section: Function Implementations
+// *****************************************************************************
+// *****************************************************************************
+
+const VERSION_INFO* VERSION_GetInfo(void)
+{
+    return &versionInfo;
+}
+
+const char* VERSION_GetString(void)
+{
+    return versionString;
+} 

--- a/version.c
+++ b/version.c
@@ -2,7 +2,7 @@
   Version Information Implementation File
 
   Company:
-    Artemis Cubesat PDU
+    Artemis Cubesat PDU: HSFL - Dennis Sarsozo
 
   File Name:
     version.c

--- a/version.h
+++ b/version.h
@@ -2,7 +2,7 @@
   Version Information Header File
 
   Company:
-    HSFL - Dennis Sarsozo
+    Artemis Cubesat PDU: HSFL - Dennis Sarsozo
 
   File Name:
     version.h

--- a/version.h
+++ b/version.h
@@ -1,0 +1,65 @@
+/*******************************************************************************
+  Version Information Header File
+
+  Company:
+    HSFL - Dennis Sarsozo
+
+  File Name:
+    version.h
+
+  Summary:
+    This header file provides version information for the PDU firmware.
+
+  Description:
+    This header file defines the version information structure and macros for
+    tracking firmware versions and build numbers.
+*******************************************************************************/
+
+#ifndef VERSION_H
+#define VERSION_H
+
+// *****************************************************************************
+// *****************************************************************************
+// Section: Included Files
+// *****************************************************************************
+// *****************************************************************************
+
+#include <stdint.h>
+
+// *****************************************************************************
+// *****************************************************************************
+// Section: Version Information
+// *****************************************************************************
+// *****************************************************************************
+
+/* Version Information Structure */
+typedef struct {
+    uint8_t major;      /* Major version number */
+    uint8_t minor;      /* Minor version number */
+    uint8_t patch;      /* Patch version number */
+    uint32_t build;     /* Build number */
+} VERSION_INFO;
+
+/* Current Version Information */
+#define VERSION_MAJOR       1
+#define VERSION_MINOR       0
+#define VERSION_PATCH       0
+#define VERSION_BUILD       1
+
+/* Version String Macros */
+#define VERSION_STRINGIFY(x) #x
+#define VERSION_MAKE_STRING(x) VERSION_STRINGIFY(x)
+
+#define VERSION_STRING \
+    VERSION_MAKE_STRING(VERSION_MAJOR) "." \
+    VERSION_MAKE_STRING(VERSION_MINOR) "." \
+    VERSION_MAKE_STRING(VERSION_PATCH) "-" \
+    VERSION_MAKE_STRING(VERSION_BUILD)
+
+/* Function to get version information */
+const VERSION_INFO* VERSION_GetInfo(void);
+
+/* Function to get version string */
+const char* VERSION_GetString(void);
+
+#endif /* VERSION_H */ 


### PR DESCRIPTION
Allows logging and versioning of the PDU's MCU software (you can have different hardware versions and software versions installed on the PDU)